### PR TITLE
修正 go run 命令行错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ __go run__ 方式：
 
 ```bash
 # 可以指定目录（要绝对路径），$(pwd) 就是当前所在目录的绝对路径
-go build -root=$(pwd)
+go run -root=$(pwd)
 ```
 
 此时就可以访问了，如配置文件默认的 8091 端口，在浏览器访问 [http://localhost:8091](http://localhost:8091)


### PR DESCRIPTION
其实不太清楚为什么必须指定 -root=$(pwd) 的方式，然后再在程序中拼接绝对地址。像分类的配置文件直接用以下写法不是更简洁吗：
```
func getCategoriesPath() string {
	return "config/categories.toml"
}
```